### PR TITLE
Add animated showcase task marquee

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -130,3 +130,28 @@ body {
   color: #fff;
   margin-top: 4rem;
 }
+
+.showcase-tasks {
+  background-color: #000;
+  color: #fff;
+  overflow: hidden;
+  white-space: nowrap;
+  padding: 0.5rem 0;
+  margin-top: 4rem; /* space below fixed header */
+}
+
+.task-marquee {
+  display: inline-block;
+  animation: marquee 20s linear infinite;
+}
+
+.task-marquee span {
+  display: inline-block;
+  margin-right: 2rem;
+  font-weight: 700;
+}
+
+@keyframes marquee {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}

--- a/index.html
+++ b/index.html
@@ -19,6 +19,21 @@
     </nav>
   </header>
 
+  <div class="showcase-tasks">
+    <div class="task-marquee">
+      <span>Responsive Design</span>
+      <span>Smooth Animations</span>
+      <span>Contact Form</span>
+      <span>Project Showcase</span>
+      <span>Open Source</span>
+      <span>Responsive Design</span>
+      <span>Smooth Animations</span>
+      <span>Contact Form</span>
+      <span>Project Showcase</span>
+      <span>Open Source</span>
+    </div>
+  </div>
+
   <section class="hero">
     <h1>Welcome to my Portfolio</h1>
     <p>Full-stack developer with a passion for building modern web experiences.</p>


### PR DESCRIPTION
## Summary
- add scrolling section between navigation and hero
- animate tasks in a marquee style

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684eb33843f08326ad2700d6dda262b4